### PR TITLE
Update gpg key for aptly repo

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Mike Purvis
 
 # Instructions from: http://www.aptly.info/download/
 RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list; \
-apt-key adv --keyserver keys.gnupg.net --recv-keys 2A194991; \
+apt-key adv --keyserver keys.gnupg.net --recv-keys 9C7DE460; \
 apt-get update; \
 apt-get install aptly -y
 


### PR DESCRIPTION
It had a new gpg signing key

```
root@2782fc5db71d:/# apt-get update
Hit http://security.debian.org jessie/updates InRelease
Get:1 http://security.debian.org jessie/updates/main amd64 Packages [548 kB]                       
Get:2 http://repo.aptly.info squeeze InRelease [4868 B]                                         
Ign http://http.debian.net jessie InRelease                                                            
Hit http://http.debian.net jessie-updates InRelease                                                  
Err http://repo.aptly.info squeeze InRelease                              
  
Hit http://http.debian.net jessie Release.gpg                             
Hit http://http.debian.net jessie Release         
Get:3 http://http.debian.net jessie-updates/main amd64 Packages [23.1 kB]
Get:4 http://http.debian.net jessie/main amd64 Packages [9063 kB]
Fetched 9639 kB in 5s (1667 kB/s)   
Reading package lists... Done
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://repo.aptly.info squeeze InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9E3E53F19C7DE460

W: Failed to fetch http://repo.aptly.info/dists/squeeze/InRelease  

W: Some index files failed to download. They have been ignored, or old ones used instead.
root@2782fc5db71d:/# apt-key adv --keyserver keys.gnupg.net --recv-keys 9E3E53F19C7DE460
Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --homedir /tmp/tmp.UPB2nL8Y1z --no-auto-check-trustdb --trust-model always --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-security-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-jessie-stable.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-squeeze-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-squeeze-stable.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-wheezy-automatic.gpg --keyring /etc/apt/trusted.gpg.d/debian-archive-wheezy-stable.gpg --keyserver keys.gnupg.net --recv-keys 9E3E53F19C7DE460
gpg: requesting key 9C7DE460 from hkp server keys.gnupg.net
gpg: key 9C7DE460: public key "Andrey Smirnov <me@smira.ru>" imported
gpg: Total number processed: 1
gpg:               imported: 1  (RSA: 1)
root@2782fc5db71d:/# apt-get update
```